### PR TITLE
テストを通しました。

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ただし、中身が実装されていません。
 実装して、ユニットテストが通るようにしてください。
 
-[![MS Build and Test](https://github.com/tpu-game-2023/comp2_6_stack/actions/workflows/ms_test.yml/badge.svg)](https://github.com/tpu-game-2023/comp2_6_stack/actions/workflows/ms_test.yml)
+[![MS Build and Test](https://github.com/BlueAiu/comp2_6_stack/actions/workflows/ms_test.yml/badge.svg)](https://github.com/BlueAiu/comp2_6_stack/actions/workflows/ms_test.yml)
 
 （このファイルの上の行の[tpu-game-2023]の部分(2か所)を自分のアカウント名に修正してください）
 

--- a/src/StaticLib/StaticLib.c
+++ b/src/StaticLib/StaticLib.c
@@ -11,9 +11,10 @@ void initialize(STACK* s, size_t mem_size)
 	if (s == NULL) return;
 
 	// ToDo: mem_sizeでメモリを確保しよう
-	s->stack_pointer = NULL;
-	s->stack_memory = NULL;
-	s->end = NULL;
+	s->stack_memory = malloc(mem_size);
+	if (s->stack_memory == NULL) return -1;
+
+	s->stack_pointer = s->end = s->stack_memory + mem_size;
 }
 
 
@@ -21,6 +22,10 @@ void initialize(STACK* s, size_t mem_size)
 void finalize(STACK* s)
 {
 	// ToDo: Initializeで確保したメモリを解放しよう
+	if (s != NULL) {
+		free(s->stack_memory);
+		s->end = s->stack_memory = s->stack_pointer = NULL;
+	}
 }
 
 
@@ -28,7 +33,13 @@ void finalize(STACK* s)
 bool push(STACK* s, int val)
 {
 	// ToDo: valの値をスタックに保存しよう
-	return false;
+	if (s == NULL || s->stack_pointer <= s->stack_memory)
+		return false;
+
+	s->stack_pointer -= sizeof(int);
+	int* p = s->stack_pointer;
+	*p = val;
+	return true;
 }
 
 
@@ -36,7 +47,13 @@ bool push(STACK* s, int val)
 bool push_array(STACK* s, int* addr, int num)
 {
 	// ToDo: addrからはじまるnum個の整数をスタックに保存しよう
-	return false;
+	if(s == NULL || addr == NULL || s->stack_pointer - sizeof(addr) < s->stack_memory)
+		return false;
+
+	for (int i = num - 1; i >= 0; i--) {
+		push(s, addr[i]);
+	}
+	return true;
 }
 
 // スタックから一つの要素を取り出す
@@ -44,7 +61,13 @@ int pop(STACK* s)
 {
 	// ToDo: スタックの最上位の値を取り出して返そう
 	// 不具合時は0を返す
-	return 0;
+	if(s == NULL || s->stack_pointer >= s->end)
+		return 0;
+
+	int* p = s->stack_pointer;
+	int val = *p;
+	s->stack_pointer += sizeof(int);
+	return val;
 }
 
 // addrにスタックからnumの要素を取り出す。取り出せた個数を返す
@@ -53,5 +76,15 @@ int pop_array(STACK* s, int* addr, int num)
 	// ToDo: スタックからnum個の値を取り出してaddrから始まるメモリに保存しよう
 	// スタックにnum個の要素がたまっていなかったら、積まれている要素を返して、
 	// 積んだ要素数を返り値として返そう
-	return 0;
+	if(s == NULL || addr == NULL || s->stack_pointer >= s->end)
+		return 0;
+
+	int i;
+	for (i = 0; i < num; i++) {
+		addr[i] = pop(s);
+		if (s->stack_pointer == s->end) {
+			i++; break;
+		}
+	}
+	return i;
 }

--- a/src/StaticLib/StaticLib.c
+++ b/src/StaticLib/StaticLib.c
@@ -11,10 +11,11 @@ void initialize(STACK* s, size_t mem_size)
 	if (s == NULL) return;
 
 	// ToDo: mem_sizeでメモリを確保しよう
-	s->stack_memory = malloc(mem_size);
-	if (s->stack_memory == NULL) return -1;
+	s->stack_memory = (int*)malloc(mem_size);
+	if (s->stack_memory == NULL) return;
 
-	s->stack_pointer = s->end = s->stack_memory + mem_size;
+	s->capacity = mem_size / sizeof(int);
+	s->num = 0;
 }
 
 
@@ -22,9 +23,10 @@ void initialize(STACK* s, size_t mem_size)
 void finalize(STACK* s)
 {
 	// ToDo: Initializeで確保したメモリを解放しよう
-	if (s != NULL) {
+	if (s != NULL && s->stack_memory != NULL) {
 		free(s->stack_memory);
-		s->end = s->stack_memory = s->stack_pointer = NULL;
+		s->stack_memory = NULL;
+		s->num = s->capacity = 0;
 	}
 }
 
@@ -33,12 +35,11 @@ void finalize(STACK* s)
 bool push(STACK* s, int val)
 {
 	// ToDo: valの値をスタックに保存しよう
-	if (s == NULL || s->stack_pointer <= s->stack_memory)
+	if (s == NULL || s->num >= s->capacity)
 		return false;
 
-	s->stack_pointer -= sizeof(int);
-	int* p = s->stack_pointer;
-	*p = val;
+	s->stack_memory[s->num] = val;
+	s->num++;
 	return true;
 }
 
@@ -47,7 +48,7 @@ bool push(STACK* s, int val)
 bool push_array(STACK* s, int* addr, int num)
 {
 	// ToDo: addrからはじまるnum個の整数をスタックに保存しよう
-	if(s == NULL || addr == NULL || s->stack_pointer - sizeof(addr) < s->stack_memory)
+	if (s == NULL || addr == NULL || num <= 0 || s->num + num > s->capacity)
 		return false;
 
 	for (int i = num - 1; i >= 0; i--) {
@@ -61,12 +62,11 @@ int pop(STACK* s)
 {
 	// ToDo: スタックの最上位の値を取り出して返そう
 	// 不具合時は0を返す
-	if(s == NULL || s->stack_pointer >= s->end)
+	if (s == NULL || s->num <= 0)
 		return 0;
 
-	int* p = s->stack_pointer;
-	int val = *p;
-	s->stack_pointer += sizeof(int);
+	s->num--;
+	int val = s->stack_memory[s->num];
 	return val;
 }
 
@@ -76,15 +76,16 @@ int pop_array(STACK* s, int* addr, int num)
 	// ToDo: スタックからnum個の値を取り出してaddrから始まるメモリに保存しよう
 	// スタックにnum個の要素がたまっていなかったら、積まれている要素を返して、
 	// 積んだ要素数を返り値として返そう
-	if(s == NULL || addr == NULL || s->stack_pointer >= s->end)
+	if (s == NULL || addr == NULL || num <= 0)
 		return 0;
 
-	int i;
-	for (i = 0; i < num; i++) {
-		addr[i] = pop(s);
-		if (s->stack_pointer == s->end) {
-			i++; break;
+	int i = 0;
+	while (i < num) {
+		if (s->num > 0) {
+			addr[i] = pop(s);
+			i++;
 		}
+		else break;
 	}
 	return i;
 }

--- a/src/include/lib_func.h
+++ b/src/include/lib_func.h
@@ -28,9 +28,11 @@ extern "C" {
 
 	typedef struct
 	{
-		int* stack_pointer;
+		//int* stack_pointer;
+		int num;
 		int* stack_memory;
-		int* end;          // スタックが底をついたか確認するためのポインタ（構造体を変更して別実装にしても良い）
+		//int* end;          // スタックが底をついたか確認するためのポインタ（構造体を変更して別実装にしても良い）
+		int capacity;		// アドレスの連続性を確保するために、配列を用いた実装にした
 	}STACK;
 
 	void initialize(STACK* s, size_t mem_size);   // mem_size の容量でスタック用のメモリを確保する


### PR DESCRIPTION
ポインタを用いたスタック構造では、mallocのポインタの連続性を確保できず、テスト(大量に（１０００万）積む)を通すことができませんでした。
スタックの構造体を変更し、配列と整数値による操作でスタック構造を実装しています。
上のテストも通すことが出来ましたが、テストに1~3分と時間を要し、連続性を確保できるポインタを用いればアクセスの手間を削減したより早い時間で処理出来たと思います。